### PR TITLE
Added set_epoch in Trainable to ensure shuffle works with DistributedSampler.

### DIFF
--- a/taglets/pipeline/trainable.py
+++ b/taglets/pipeline/trainable.py
@@ -199,10 +199,13 @@ class Trainable:
         val_loss_list = []
         val_acc_list = []
 
-        # Iterates over epochs
+        # Iterates over epochs()
         for epoch in range(self.num_epochs):
             if rank == 0:
                 log.info("Epoch {}: ".format(epoch + 1))
+
+            # this is necessary for shuffle to work
+            train_sampler.set_epoch(epoch)
 
             # Trains on training data
             train_loss, train_acc = self._train_epoch(train_data_loader, use_gpu)


### PR DESCRIPTION
According to the Pytorch documentation for DistributedSampler, we need to call set_epoch at every training epoch to ensure that batches are shuffled correctly. This is due to the fact that DistributedSampler sets the seed used for shuffling equal to the current epoch. This is a minute issue, but see [here](https://github.com/pytorch/pytorch/issues/31771) and [here](https://pytorch.org/docs/stable/_modules/torch/utils/data/distributed.html#DistributedSampler) for more information.